### PR TITLE
🤖 [Auto] 旅行計画コンポーネントに観光スポットのメモ機能を追加し、メモの文字数制限を1000文字に設定。関連する型定義を更新。

### DIFF
--- a/src/components/TravelPlan.tsx
+++ b/src/components/TravelPlan.tsx
@@ -6,6 +6,9 @@ import Image from 'next/image';
 import { TravelPlanType } from '@/types/plan';
 import { useStoreForPlanning } from '@/lib/plan';
 
+import { Label } from './ui/label';
+import { Textarea } from './ui/textarea';
+
 const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
   const fields = useStoreForPlanning();
   if (!travelPlan) {
@@ -15,10 +18,10 @@ const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
   const targetSimulationStatus = fields.simulationStatus
     ? fields.simulationStatus.filter(
         (val) => val.date.toLocaleDateString('ja-JP') == travelPlan.date.toLocaleDateString('ja-JP'),
-      )[0].status
+      )[0]?.status
     : null;
 
-  const { departure, spots, destination } = travelPlan;
+  const { departure, spots, destination, date } = travelPlan;
 
   const transportIcons: Record<string, JSX.Element> = {
     電車: <Train className="w-5 h-5 text-blue-500" />,
@@ -114,12 +117,21 @@ const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
               ))}
             </div>
 
-            {/* キャッチコピー */}
-
             {/* 説明 (吹き出し風) */}
             <div className="mt-4 bg-gray-100 p-3 rounded-lg shadow-sm">
+              {/* キャッチコピー */}
               <p className="mb-2 text-sm font-semibold text-gray-700">{spot.catchphrase}</p>
               <p className="text-gray-600 text-sm">{spot.description}</p>
+            </div>
+
+            {/* 観光スポットに対するメモ */}
+            <div className="mt-4 border-t border-gray-300 py-6">
+              <Label className="font-semibold text-lg">メモ</Label>
+              <Textarea
+                placeholder="この観光スポットに対するメモや注意点を記載"
+                value={spot.memo || ''}
+                onChange={(e) => fields.setSpots(new Date(date), { ...spot, memo: e.target.value }, false)}
+              />
             </div>
           </div>
         </div>

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -22,7 +22,7 @@ export const schema = z.object({
       transportation_method: z.array(z.number()).refine((value) => value.some((item) => item), {
         message: '移動手段は最低でも1つ以上選択してください',
       }),
-      memo: z.string().optional(),
+      memo: z.string().max(1000, { message: 'メモは1000文字以内で記載をお願いします' }).optional(),
     }),
   ),
   plans: z.array(
@@ -46,6 +46,7 @@ export const schema = z.object({
           start: z.string().time(),
           end: z.string().time(),
         }),
+        memo: z.string().max(1000, { message: 'メモは1000文字以内で記載をお願いします' }).optional(),
         image: z.string().url().optional(),
         rating: z.number().optional(),
         category: z.array(z.string()),

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -37,6 +37,7 @@ export type Spot = {
   lng: number;
   stay: StayDuration;
   transport: Transport;
+  memo?: string;
   image?: string; // 画像URL (省略可能)
   rating: number; // 例: 4.7
   category: string[]; // 例: ["文化", "歴史"]


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    旅行計画コンポーネントに観光スポットのメモ機能を追加し、メモの文字数制限を1000文字に設定。関連する型定義を更新。

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 旅行プラン画面に各観光スポットごとのメモ入力欄を追加し、ツアーに関する注意やコメントを記録できるようになりました。

- **バグ修正**
  - メモ入力に1000文字以内の制限を設け、入力内容の品質向上とシステムの安定性改善を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->