### PR TITLE
🤖 [Auto] 旅行計画関連のフィールド名を変更し、start_dateとend_dateをそれぞれstartDateとendDateに統一。これに伴い、関連するコンポーネントやスキーマも修正。API呼び出し時のトークン取得機能を追加し、エラーハンドリングを強化。

### DIFF
--- a/backend/src/controllers/trip.ts
+++ b/backend/src/controllers/trip.ts
@@ -109,14 +109,14 @@ export const getTripHandler = {
       const newTrip = await prisma.trip.create({
         data: {
           title: trip.title,
-          startDate: new Date(trip.start_date),
-          endDate: new Date(trip.end_date),
+          startDate: new Date(trip.startDate),
+          endDate: new Date(trip.endDate),
           userId: auth.userId,
           tripInfo: {
             create: trip.tripInfo.map((info) => ({
               date: new Date(info.date),
-              genreId: info.genre_id,
-              transportationMethods: info.transportation_method,
+              genreId: info.genreId,
+              transportationMethods: info.transportationMethod,
               memo: info.memo,
             })),
           },

--- a/backend/src/models/trip.ts
+++ b/backend/src/models/trip.ts
@@ -5,13 +5,13 @@ export const TripSchema = z.object({
     .string()
     .min(1, { message: 'タイトルは必須です' })
     .max(50, { message: 'タイトルの上限を超えています。50文字以下で入力してください' }),
-  start_date: z.coerce.date({ message: '予定日の開始日を入力してください' }),
-  end_date: z.coerce.date({ message: '予定日の終了日を入力してください' }),
+  startDate: z.coerce.date({ message: '予定日の開始日を入力してください' }),
+  endDate: z.coerce.date({ message: '予定日の終了日を入力してください' }),
   tripInfo: z.array(
     z.object({
       date: z.coerce.date(),
-      genre_id: z.number(),
-      transportation_method: z.array(z.number()).refine((value) => value.some((item) => item), {
+      genreId: z.number(),
+      transportationMethod: z.array(z.number()).refine((value) => value.some((item) => item), {
         message: '移動手段は最低でも1つ以上選択してください',
       }),
       memo: z.string().max(1000, { message: 'メモは1000文字以内で記載をお願いします' }).optional(),

--- a/frontend/src/app/plan/[id]/page.tsx
+++ b/frontend/src/app/plan/[id]/page.tsx
@@ -6,6 +6,7 @@ import useSWR from 'swr';
 import { Clock, Pencil, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 import Link from 'next/link';
+import { useAuth } from '@clerk/nextjs';
 
 import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -14,11 +15,21 @@ import { DayPlan } from '@/components/DayPlan';
 import { Button } from '@/components/ui/button';
 import { FormData } from '@/lib/plan';
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
-
 const PageDetail = () => {
+  const { getToken } = useAuth();
+  const fetcher = async (url: string) => {
+    const token = await getToken();
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      method: 'GET',
+    });
+    return response.json();
+  };
   const router = useParams();
-  const { data: trip, error, isLoading } = useSWR(`/api/trips/${router.id}`, fetcher);
+  const { data: trip, error, isLoading } = useSWR(`http://localhost:8787/api/trips/${router.id}`, fetcher);
 
   if (error) return <div className="container mx-auto py-8 text-center">エラーが発生しました</div>;
   if (isLoading || !trip) return <div className="container mx-auto py-8 text-center">読み込み中...</div>;

--- a/frontend/src/app/plan/create/page.tsx
+++ b/frontend/src/app/plan/create/page.tsx
@@ -82,17 +82,17 @@ const TravelPlanCreate = () => {
                       variant={'outline'}
                       className={cn(
                         'w-full justify-start text-left font-normal',
-                        !fields.start_date && 'text-muted-foreground',
+                        !fields.startDate && 'text-muted-foreground',
                       )}
                     >
                       <CalendarIcon className="mr-2 h-4 w-4" />
-                      {fields.start_date ? (
-                        fields.end_date ? (
+                      {fields.startDate ? (
+                        fields.endDate ? (
                           <>
-                            {format(fields.start_date, 'yyyy/MM/dd')} 〜 {format(fields.end_date, 'yyyy/MM/dd')}
+                            {format(fields.startDate, 'yyyy/MM/dd')} 〜 {format(fields.endDate, 'yyyy/MM/dd')}
                           </>
                         ) : (
-                          format(fields.start_date, 'yyyy/MM/dd')
+                          format(fields.startDate, 'yyyy/MM/dd')
                         )
                       ) : (
                         <span>日付範囲を選択</span>
@@ -103,10 +103,10 @@ const TravelPlanCreate = () => {
                     <Calendar
                       initialFocus
                       mode="range"
-                      defaultMonth={fields.start_date}
+                      defaultMonth={fields.startDate}
                       selected={{
-                        from: fields.start_date,
-                        to: fields.end_date,
+                        from: fields.startDate,
+                        to: fields.endDate,
                       }}
                       onSelect={(dateRange: DateRange | undefined) => {
                         fields.setRangeDate({
@@ -119,22 +119,22 @@ const TravelPlanCreate = () => {
                   </PopoverContent>
                 </Popover>
                 <div className="my-1">
-                  {fields.errors.start_date && (
-                    <span className="text-red-500">{fields.errors.start_date.toString()}</span>
+                  {fields.errors.startDate && (
+                    <span className="text-red-500">{fields.errors.startDate.toString()}</span>
                   )}
                 </div>
               </div>
 
               {/* 選択した日付分だけタブが生成されるようにする */}
-              <Tabs defaultValue={fields.start_date.toLocaleDateString('ja-JP')} defaultChecked={true}>
+              <Tabs defaultValue={fields.startDate.toLocaleDateString('ja-JP')} defaultChecked={true}>
                 <TabsList className="flex justify-start space-x-2">
-                  {getDatesBetween(fields.start_date, fields.end_date).map((date) => (
+                  {getDatesBetween(fields.startDate, fields.endDate).map((date) => (
                     <TabsTrigger key={date} value={date}>
                       {date}
                     </TabsTrigger>
                   ))}
                 </TabsList>
-                {getDatesBetween(fields.start_date, fields.end_date).map((date) => (
+                {getDatesBetween(fields.startDate, fields.endDate).map((date) => (
                   <TabsContent key={date} value={date}>
                     <PlanningComp date={date} />
                   </TabsContent>

--- a/frontend/src/app/plan/list/page.tsx
+++ b/frontend/src/app/plan/list/page.tsx
@@ -38,8 +38,8 @@ export default function TripsPage() {
             key={idx}
             id={idx}
             title={trip.title}
-            start_date={trip.startDate}
-            end_date={trip.endDate}
+            startDate={trip.startDate}
+            endDate={trip.endDate}
             imageUrl={trip.plans?.[0]?.spots?.[0]?.image}
           />
         ))}

--- a/frontend/src/components/PlanningButton.tsx
+++ b/frontend/src/components/PlanningButton.tsx
@@ -11,24 +11,24 @@ const PlanningButton = ({ date }: { date: string }) => {
     let isError = false;
     fields.resetErrors();
     //推した時点で予定日、目的地、出発地、交通手段、観光スポットが空の場合はエラーを出す
-    if (!fields.start_date || !fields.end_date) {
-      fields.setErrors({ start_date: 'プランの日付を入力してください' });
+    if (!fields.startDate || !fields.endDate) {
+      fields.setErrors({ startDate: 'プランの日付を入力してください' });
       isError = true;
     }
 
     const targetTripInfo = fields.tripInfo.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0];
     const targetPlans = fields.plans.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0];
 
-    if (!targetTripInfo || !targetTripInfo.transportation_method.length) {
+    if (!targetTripInfo || !targetTripInfo.transportationMethod.length) {
       fields.setTripInfoErrors(new Date(date), {
-        transportation_method: '計画設定の移動手段を一つ以上チェックしてください',
+        transportationMethod: '計画設定の移動手段を一つ以上チェックしてください',
       });
       isError = true;
     }
 
-    if (!targetTripInfo || !targetTripInfo.genre_id) {
+    if (!targetTripInfo || !targetTripInfo.genreId) {
       fields.setTripInfoErrors(new Date(date), {
-        genre_id: '計画設定のジャンルを選択してください',
+        genreId: '計画設定のジャンルを選択してください',
       });
       isError = true;
     }

--- a/frontend/src/components/PlanningComp.tsx
+++ b/frontend/src/components/PlanningComp.tsx
@@ -25,7 +25,7 @@ const PlanningComp = ({ date }: { date: string }) => {
         <Select
           onValueChange={(value) => fields.setTripInfo(new Date(date), 'genre_id', value)}
           value={
-            fields.tripInfo.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0]?.genre_id.toString() || ''
+            fields.tripInfo.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0]?.genreId.toString() || ''
           }
         >
           <SelectTrigger>
@@ -40,7 +40,7 @@ const PlanningComp = ({ date }: { date: string }) => {
           </SelectContent>
         </Select>
 
-        {fields.tripInfoErrors && <span className="text-red-500">{fields.tripInfoErrors[date]?.genre_id}</span>}
+        {fields.tripInfoErrors && <span className="text-red-500">{fields.tripInfoErrors[date]?.genreId}</span>}
       </div>
       {/* メインとなる移動手段 */}
       <div className="space-y-4">

--- a/frontend/src/components/Transportation.tsx
+++ b/frontend/src/components/Transportation.tsx
@@ -18,13 +18,13 @@ const Transportation = ({ date }: { date: string }) => {
               <Checkbox
                 checked={(
                   fields.tripInfo.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0]
-                    ?.transportation_method || []
+                    ?.transportationMethod || []
                 ).includes(method.id)}
                 className="h-5 w-5 text-blue-500 focus:ring-2 focus:ring-blue-400"
                 onCheckedChange={(checked) => {
                   const targetList =
                     fields.tripInfo.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0]
-                      ?.transportation_method || [];
+                      ?.transportationMethod || [];
                   const isIncluded = targetList.includes(method.id);
                   if (checked && !isIncluded) {
                     fields.setTripInfo(new Date(date), 'transportation_method', [...targetList, method.id]);
@@ -43,7 +43,7 @@ const Transportation = ({ date }: { date: string }) => {
         ))}
       </div>
       {fields.tripInfoErrors && (
-        <span className="text-red-500">{fields.tripInfoErrors[date]?.transportation_method}</span>
+        <span className="text-red-500">{fields.tripInfoErrors[date]?.transportationMethod}</span>
       )}
     </div>
   );

--- a/frontend/src/components/TripCard.tsx
+++ b/frontend/src/components/TripCard.tsx
@@ -7,12 +7,12 @@ import { Card, CardContent } from '@/components/ui/card';
 type TripCardProps = {
   id: string | number;
   title: string;
-  start_date: Date;
-  end_date: Date;
+  startDate: Date;
+  endDate: Date;
   imageUrl?: string;
 };
 
-export const TripCard = ({ id, title, start_date, end_date, imageUrl }: TripCardProps) => {
+export const TripCard = ({ id, title, startDate, endDate, imageUrl }: TripCardProps) => {
   return (
     <Link href={`/plan/${id}`}>
       <Card className="overflow-hidden">
@@ -22,9 +22,9 @@ export const TripCard = ({ id, title, start_date, end_date, imageUrl }: TripCard
         <CardContent className="p-4">
           <h3 className="text-lg font-bold mb-2 line-clamp-1">{title}</h3>
           <div className="flex text-sm text-gray-600">
-            <p>{format(start_date, 'yyyy/MM/dd')}</p>
+            <p>{format(startDate, 'yyyy/MM/dd')}</p>
             <p>〜</p>
-            <p>{format(end_date, 'yyyy/MM/dd')}</p>
+            <p>{format(endDate, 'yyyy/MM/dd')}</p>
           </div>
         </CardContent>
       </Card>

--- a/frontend/src/components/TripDetail.tsx
+++ b/frontend/src/components/TripDetail.tsx
@@ -15,8 +15,8 @@ type TripDetailProps = {
     endDate: string;
     tripInfo: {
       date: string;
-      genre_id: number;
-      transportation_method: number[];
+      genreId: number;
+      transportationMethod: number[];
       memo: string | null;
     }[];
     plans: {

--- a/frontend/src/data/dummyData.ts
+++ b/frontend/src/data/dummyData.ts
@@ -343,13 +343,13 @@ export const transportationMethods = [
 
 export const dummyData = {
   title: '夏の旅行計画1泊2日',
-  start_date: new Date('2025-07-15T00:00:00.000Z'),
-  end_date: new Date('2025-07-16T00:00:00.000Z'),
+  startDate: new Date('2025-07-15T00:00:00.000Z'),
+  endDate: new Date('2025-07-16T00:00:00.000Z'),
   tripInfo: [
     {
       date: new Date('2025-07-15T00:00:00.000Z'),
-      genre_id: 1,
-      transportation_method: [1, 2], // 空配列ではなく、最低1つ入れる
+      genreId: 1,
+      transportationMethod: [1, 2], // 空配列ではなく、最低1つ入れる
       memo: '移動時間が長いので休憩をしっかり取る。',
     },
   ],

--- a/frontend/src/lib/plan.ts
+++ b/frontend/src/lib/plan.ts
@@ -15,13 +15,13 @@ export const schema = z.object({
     .min(1, { message: 'タイトルは必須です' })
     .max(50, { message: 'タイトルの上限を超えています。50文字以下で入力してください' }),
   imageUrl: z.string().url().optional(),
-  start_date: z.date({ message: '予定日の開始日を入力してください' }),
-  end_date: z.date({ message: '予定日の終了日を入力してください' }),
+  startDate: z.date({ message: '予定日の開始日を入力してください' }),
+  endDate: z.date({ message: '予定日の終了日を入力してください' }),
   tripInfo: z.array(
     z.object({
       date: z.date(),
-      genre_id: z.number(),
-      transportation_method: z.array(z.number()).refine((value) => value.some((item) => item), {
+      genreId: z.number(),
+      transportationMethod: z.array(z.number()).refine((value) => value.some((item) => item), {
         message: '移動手段は最低でも1つ以上選択してください',
       }),
       memo: z.string().max(1000, { message: 'メモは1000文字以内で記載をお願いします' }).optional(),
@@ -75,8 +75,8 @@ export type FormData = z.infer<typeof schema>;
 interface FormState {
   title: string;
   imageUrl?: string;
-  start_date: Date;
-  end_date: Date;
+  startDate: Date;
+  endDate: Date;
   tripInfo: TripInfo[];
   plans: TravelPlanType[];
   errors: Partial<Record<keyof FormData, string>>;
@@ -107,8 +107,8 @@ export const useStoreForPlanning = create<FormState>()(
     devtools((set) => ({
       title: '',
       imageUrl: '',
-      start_date: new Date(),
-      end_date: new Date(),
+      startDate: new Date(),
+      endDate: new Date(),
       tripInfo: [],
       plans: [
         {
@@ -163,8 +163,8 @@ export const useStoreForPlanning = create<FormState>()(
           } else {
             state.tripInfo.push({
               date: removeTimeFromDate(date),
-              genre_id: name === 'genre_id' ? Number(value) : 0,
-              transportation_method: name === 'transportation_method' ? (value as number[]) : [],
+              genreId: name === 'genre_id' ? Number(value) : 0,
+              transportationMethod: name === 'transportation_method' ? (value as number[]) : [],
               memo: name === 'memo' ? (value as string) : '',
             });
           }
@@ -218,7 +218,7 @@ export const useStoreForPlanning = create<FormState>()(
         set((state) => {
           state[field] = value;
         }),
-      setRangeDate: (date) => set((state) => ({ ...state, start_date: date?.from, end_date: date?.to })),
+      setRangeDate: (date) => set((state) => ({ ...state, startDate: date?.from, endDate: date?.to })),
       setErrors: (errors) => set((state) => ({ ...state, errors })),
       setTripInfoErrors: (date, errors) =>
         set((state) => {

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -27,8 +27,8 @@ type NearestStation = {
 
 export type TripInfo = {
   date: Date;
-  genre_id: number;
-  transportation_method: number[];
+  genreId: number;
+  transportationMethod: number[];
   memo?: string;
 };
 


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    旅行計画関連のフィールド名を変更し、start_dateとend_dateをそれぞれstartDateとendDateに統一。これに伴い、関連するコンポーネントやスキーマも修正。API呼び出し時のトークン取得機能を追加し、エラーハンドリングを強化。

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
  - 全体的にプロパティ名をスネークケースからキャメルケース（例：start_date → startDate、end_date → endDate、genre_id → genreId、transportation_method → transportationMethod）へ統一しました。

- **バグ修正**
  - プロパティ名変更に伴い、各画面・コンポーネント・バリデーション・ダミーデータ・型定義などでの参照ミスを修正しました。

- **ドキュメント**
  - 型定義やダミーデータのプロパティ名もキャメルケースに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->