### PR TITLE
🤖 [Auto] 旅行計画関連のフィールド名を変更し、'genre_id'と'transportation_method'をそれぞれ'genreId'と'transportationMethod'に統一。関連するコンポーネントでの修正を実施。

### DIFF
--- a/frontend/src/components/PlanningComp.tsx
+++ b/frontend/src/components/PlanningComp.tsx
@@ -23,7 +23,7 @@ const PlanningComp = ({ date }: { date: string }) => {
       <div className="space-y-2">
         <Label>旅行ジャンル</Label>
         <Select
-          onValueChange={(value) => fields.setTripInfo(new Date(date), 'genre_id', value)}
+          onValueChange={(value) => fields.setTripInfo(new Date(date), 'genreId', value)}
           value={
             fields.tripInfo.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0]?.genreId.toString() || ''
           }

--- a/frontend/src/components/Transportation.tsx
+++ b/frontend/src/components/Transportation.tsx
@@ -27,11 +27,11 @@ const Transportation = ({ date }: { date: string }) => {
                       ?.transportationMethod || [];
                   const isIncluded = targetList.includes(method.id);
                   if (checked && !isIncluded) {
-                    fields.setTripInfo(new Date(date), 'transportation_method', [...targetList, method.id]);
+                    fields.setTripInfo(new Date(date), 'transportationMethod', [...targetList, method.id]);
                   } else if (!checked && isIncluded) {
                     fields.setTripInfo(
                       new Date(date),
-                      'transportation_method',
+                      'transportationMethod',
                       targetList.filter((id) => id !== method.id),
                     );
                   }

--- a/frontend/src/lib/plan.ts
+++ b/frontend/src/lib/plan.ts
@@ -85,7 +85,7 @@ interface FormState {
   spotErrors: Partial<Record<string, Partial<Record<keyof Spot, string>>>>;
   setTripInfo: (
     date: Date,
-    name: 'date' | 'genre_id' | 'transportation_method' | 'memo',
+    name: 'date' | 'genreId' | 'transportationMethod' | 'memo',
     value: Date | number | number[] | string,
   ) => void;
   simulationStatus: { date: Date; status: number }[] | null;
@@ -155,6 +155,7 @@ export const useStoreForPlanning = create<FormState>()(
           const existingTripInfoIndex = state.tripInfo.findIndex(
             (info) => info.date.toDateString() === date.toDateString(),
           );
+
           if (existingTripInfoIndex >= 0) {
             state.tripInfo[existingTripInfoIndex] = {
               ...state.tripInfo[existingTripInfoIndex],
@@ -163,8 +164,8 @@ export const useStoreForPlanning = create<FormState>()(
           } else {
             state.tripInfo.push({
               date: removeTimeFromDate(date),
-              genreId: name === 'genre_id' ? Number(value) : 0,
-              transportationMethod: name === 'transportation_method' ? (value as number[]) : [],
+              genreId: name === 'genreId' ? Number(value) : 0,
+              transportationMethod: name === 'transportationMethod' ? (value as number[]) : [],
               memo: name === 'memo' ? (value as string) : '',
             });
           }
@@ -268,11 +269,6 @@ export type PlaceInfo = {
   url: string;
   location: Departure;
   photos: PhotoType[];
-};
-
-type Actions = {
-  getNearBySpot: () => PlaceInfo[];
-  setNearBySpot: (placeInfo: PlaceInfo[]) => void;
 };
 
 let map: google.maps.Map;


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    旅行計画関連のフィールド名を変更し、'genre_id'と'transportation_method'をそれぞれ'genreId'と'transportationMethod'に統一。関連するコンポーネントでの修正を実施。

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 入力フォームで使用されるキー名をスネークケースからキャメルケース（例: genre_id → genreId, transportation_method → transportationMethod）へ統一し、表示やエラー処理の不整合を修正しました。

- **リファクタリング**
  - 不要な型宣言（Actions型）を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->