### PR TITLE
🤖 [Auto] 旅行計画関連のフィールド名を'stay'から'stayStart'と'stayEnd'に変更し、関連するコンポーネントでの修正を実施。これにより、データの整合性を向上させ、コードの可読性を改善。

### DIFF
--- a/backend/src/controllers/trip.ts
+++ b/backend/src/controllers/trip.ts
@@ -178,8 +178,9 @@ export const getTripHandler = {
                     name: spot.name,
                     latitude: spot.latitude,
                     longitude: spot.longitude,
-                    stayStart: new Date(`2025-01-01T${spot.stay.start}`),
-                    stayEnd: new Date(`2025-01-01T${spot.stay.end}`),
+                    //TODO: 固定値になっているのを修正する
+                    stayStart: new Date(`2025-01-01T${spot.stayStart}`),
+                    stayEnd: new Date(`2025-01-01T${spot.stayEnd}`),
                     memo: spot.memo ?? '',
                     image: spot.image ?? '',
                     rating: spot.rating ?? 0,

--- a/backend/src/controllers/trip.ts
+++ b/backend/src/controllers/trip.ts
@@ -178,9 +178,8 @@ export const getTripHandler = {
                     name: spot.name,
                     latitude: spot.latitude,
                     longitude: spot.longitude,
-                    //TODO: 固定値になっているのを修正する
-                    stayStart: new Date(`2025-01-01T${spot.stayStart}`),
-                    stayEnd: new Date(`2025-01-01T${spot.stayEnd}`),
+                    stayStart: new Date(`${new Date(plan.date).toISOString().split('T')[0]}T${spot.stayStart}`),
+                    stayEnd: new Date(`${new Date(plan.date).toISOString().split('T')[0]}T${spot.stayEnd}`),
                     memo: spot.memo ?? '',
                     image: spot.image ?? '',
                     rating: spot.rating ?? 0,

--- a/backend/src/models/trip.ts
+++ b/backend/src/models/trip.ts
@@ -37,10 +37,8 @@ export const TripSchema = z.object({
           name: z.string().min(1, { message: '観光地名は必須です' }),
           latitude: z.number().min(-90).max(90, { message: '緯度は -90 から 90 の範囲で指定してください' }),
           longitude: z.number().min(-180).max(180, { message: '経度は -180 から 180 の範囲で指定してください' }),
-          stay: z.object({
-            start: z.string(), //TODO: HH:mm形式でのバリデーションにできないか考える
-            end: z.string(),
-          }),
+          stayStart: z.string(), //TODO: HH:mm形式でのバリデーションにできないか考える
+          stayEnd: z.string(),
           memo: z.string().max(1000, { message: 'メモは1000文字以内で記載をお願いします' }).optional(),
           image: z.string().optional(),
           rating: z.number().optional(),

--- a/frontend/src/app/plan/[id]/page.tsx
+++ b/frontend/src/app/plan/[id]/page.tsx
@@ -10,7 +10,6 @@ import useSWRMutation from 'swr/mutation';
 
 import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { dummyData } from '@/data/dummyData';
 import { DayPlan } from '@/components/DayPlan';
 import { Button } from '@/components/ui/button';
 import { FormData } from '@/lib/plan';
@@ -92,7 +91,7 @@ const PageDetail = () => {
             ))}
           </TabsList>
 
-          {dummyData.plans.map((plan, index) => (
+          {(trip as FormData).plans.map((plan, index) => (
             <TabsContent key={`day-${index + 1}`} value={`day-${index + 1}`}>
               <DayPlan plan={plan} dayNumber={index + 1} />
             </TabsContent>

--- a/frontend/src/components/GanttChart.tsx
+++ b/frontend/src/components/GanttChart.tsx
@@ -45,7 +45,7 @@ const GanttChart = ({ date }: { date: string }) => {
   const isStartPoint = (hour: string, minute: number, id: string) => {
     const time = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
     const targetData = spots.filter((spot) => spot.id === id)[0];
-    if (targetData.stay.start === time) {
+    if (targetData.stayStart === time) {
       return true;
     }
     return false;
@@ -56,7 +56,7 @@ const GanttChart = ({ date }: { date: string }) => {
     minute = minute == 45 ? 0 : minute + 15;
     const time = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
     const targetData = spots.filter((spot) => spot.id === id)[0];
-    if (targetData.stay.end === time) {
+    if (targetData.stayEnd === time) {
       return true;
     }
     return false;
@@ -75,7 +75,7 @@ const GanttChart = ({ date }: { date: string }) => {
     if (event.over) {
       const [spotId, newTime] = event.over.id.toString().split('-').map(String);
       if (type === 'start') {
-        const endTime = spots.filter((activity) => activity.id === draggingId)[0].stay.end;
+        const endTime = spots.filter((activity) => activity.id === draggingId)[0].stayEnd;
         // 始点が終点を超える場合はこれ以上ドラッグしない
         if (newTime >= endTime) {
           return;
@@ -84,7 +84,7 @@ const GanttChart = ({ date }: { date: string }) => {
           prev.map((activity) => (activity.id === draggingId ? { ...activity, start: newTime } : activity)),
         );
       } else if (type === 'end') {
-        const startTime = spots.filter((activity) => activity.id === draggingId)[0].stay.start;
+        const startTime = spots.filter((activity) => activity.id === draggingId)[0].stayStart;
         // 終点が始点を下回る場合はこれ以上ドラッグしない
         if (newTime <= startTime) {
           return;
@@ -94,8 +94,8 @@ const GanttChart = ({ date }: { date: string }) => {
         );
       } else {
         //現在の時間を取得
-        const startTime = spots.filter((activity) => activity.id === draggingId)[0].stay.start;
-        const endTime = spots.filter((activity) => activity.id === draggingId)[0].stay.end;
+        const startTime = spots.filter((activity) => activity.id === draggingId)[0].stayStart;
+        const endTime = spots.filter((activity) => activity.id === draggingId)[0].stayEnd;
         //選択している時間とドロップ先の差分を取得
         const diffTime = calcDiffTime(newTime, type);
         //差分をもとに始点と終点を更新
@@ -113,7 +113,7 @@ const GanttChart = ({ date }: { date: string }) => {
       const prevData = spots.filter((activity) => activity.id === spotId)[0];
       // 始点が終点を超える場合は反映させない
       if (type === 'start') {
-        if (newTime > prevData.stay.end) {
+        if (newTime > prevData.stayEnd) {
           return;
         }
         setDraggedItems((prev) =>
@@ -123,15 +123,11 @@ const GanttChart = ({ date }: { date: string }) => {
         );
         const targetSpot = spots.find((spot) => spot.id === draggedId);
         if (targetSpot) {
-          fields.setSpots(
-            new Date(date),
-            { ...targetSpot, stay: { start: newTime, end: targetSpot?.stay.end } },
-            false,
-          );
+          fields.setSpots(new Date(date), { ...targetSpot, stayStart: newTime }, false);
         }
       } else if (type === 'end') {
         // 終点が始点を下回る場合は反映しない
-        if (newTime < prevData.stay.start) {
+        if (newTime < prevData.stayStart) {
           return;
         }
         setDraggedItems((prev) =>
@@ -142,16 +138,12 @@ const GanttChart = ({ date }: { date: string }) => {
 
         const targetSpot = spots.find((spot) => spot.id === draggedId);
         if (targetSpot) {
-          fields.setSpots(
-            new Date(date),
-            { ...targetSpot, stay: { start: targetSpot?.stay.start, end: newTime } },
-            false,
-          );
+          fields.setSpots(new Date(date), { ...targetSpot, stayEnd: newTime }, false);
         }
       } else {
         //現在の時間を取得
-        const startTime = spots.filter((activity) => activity.id === spotId)[0].stay.start;
-        const endTime = spots.filter((activity) => activity.id === spotId)[0].stay.end;
+        const startTime = spots.filter((activity) => activity.id === spotId)[0].stayStart;
+        const endTime = spots.filter((activity) => activity.id === spotId)[0].stayEnd;
         //選択している時間とドロップ先の差分を取得
         const diffTime = calcDiffTime(newTime, type);
         //差分をもとに始点と終点を更新
@@ -170,7 +162,7 @@ const GanttChart = ({ date }: { date: string }) => {
         if (targetSpot) {
           fields.setSpots(
             new Date(date),
-            { ...targetSpot, stay: { start: updatedStartTime, end: updatedEndTime } },
+            { ...targetSpot, stayStart: updatedStartTime, stayEnd: updatedEndTime },
             false,
           );
         }
@@ -192,7 +184,7 @@ const GanttChart = ({ date }: { date: string }) => {
             <div key={id} className="h-16 flex items-center justify-center border-b border-gray-300 bg-gray-100">
               {spot.name}
               <div>
-                ({spot.stay.start} ~ {spot.stay.end})
+                ({spot.stayStart} ~ {spot.stayEnd})
               </div>
             </div>
           ))}
@@ -233,7 +225,7 @@ const GanttChart = ({ date }: { date: string }) => {
                           key={minute}
                           id={`${spot.id}-${timeSlot.split(':')[0]}:${String(minute).padEnd(2, '0')}`}
                         >
-                          {isTimeWithinRange(timeSlot.split(':')[0], minute, spot.stay.start, spot.stay.end) && (
+                          {isTimeWithinRange(timeSlot.split(':')[0], minute, spot.stayStart, spot.stayEnd) && (
                             <DraggableHandle
                               id={`${spot.id}-${timeSlot.split(':')[0]}:${String(minute).padEnd(2, '0')}`}
                               isStart={false}

--- a/frontend/src/components/SpotCard2.tsx
+++ b/frontend/src/components/SpotCard2.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Spot } from '@/types/plan';
 
+import { formatToHHmm } from '../lib/utils';
 interface SpotCardProps {
   spot: Spot;
   isLast?: boolean;
@@ -30,7 +31,7 @@ export function SpotCard({ spot, isLast }: SpotCardProps) {
               <p className="text-sm text-muted-foreground">{spot.catchphrase}</p>
             </div>
             <div className="flex gap-1">
-              {spot.category.map((cat) => (
+              {spot.category?.map((cat) => (
                 <Badge key={cat} variant="secondary">
                   {cat}
                 </Badge>
@@ -42,14 +43,14 @@ export function SpotCard({ spot, isLast }: SpotCardProps) {
             <div className="flex items-center gap-2 text-sm">
               <Clock className="w-4 h-4" />
               <span>
-                {spot.stay.start} - {spot.stay.end}
+                {formatToHHmm(spot.stayStart)} - {formatToHHmm(spot.stayEnd)}
               </span>
             </div>
 
             <div className="flex items-center gap-2 text-sm">
               <Train className="w-4 h-4" />
               <span>
-                {spot.transport.name} ({spot.transport.time})
+                {spot.transport?.name} ({spot.transport?.time})
               </span>
             </div>
 

--- a/frontend/src/lib/plan.ts
+++ b/frontend/src/lib/plan.ts
@@ -46,10 +46,8 @@ export const schema = z.object({
           name: z.string().min(1, { message: '観光地名は必須です' }),
           latitude: z.number().min(-90).max(90, { message: '緯度は -90 から 90 の範囲で指定してください' }),
           longitude: z.number().min(-180).max(180, { message: '経度は -180 から 180 の範囲で指定してください' }),
-          stay: z.object({
-            start: z.string().time(),
-            end: z.string().time(),
-          }),
+          stayStart: z.string().time(),
+          stayEnd: z.string().time(),
           memo: z.string().max(1000, { message: 'メモは1000文字以内で記載をお願いします' }).optional(),
           image: z.string().url().optional(),
           rating: z.number().optional(),
@@ -339,7 +337,8 @@ export async function searchByCategory(params: SearchSpotByCategoryParams): Prom
         rating: place.rating || 0,
         latitude: place.location?.lat() ?? 0,
         longitude: place.location?.lng() ?? 0,
-        stay: { start: '09:00', end: '10:00' }, //TODO:仮置き
+        stayStart: '09:00', //TODO:仮置き
+        stayEnd: '10:00', //TODO:仮置き
         category: place.types || [], //TODO: 日本語化
         transport: { name: '徒歩', time: '30分' }, //TODO:仮置き,
       });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -81,3 +81,10 @@ export const getDatesBetween = (start: Date, end: Date) => {
 export const removeTimeFromDate = (date: Date): Date => {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 };
+
+export const formatToHHmm = (date: string): string => {
+  const parsedDate = new Date(date);
+  const hours = String(parsedDate.getHours()).padStart(2, '0');
+  const minutes = String(parsedDate.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -83,8 +83,18 @@ export const removeTimeFromDate = (date: Date): Date => {
 };
 
 export const formatToHHmm = (date: string): string => {
-  const parsedDate = new Date(date);
-  const hours = String(parsedDate.getHours()).padStart(2, '0');
-  const minutes = String(parsedDate.getMinutes()).padStart(2, '0');
-  return `${hours}:${minutes}`;
+  try {
+    const parsedDate = new Date(date);
+
+    if (isNaN(parsedDate.getTime())) {
+      console.error('Invalid date:', date);
+      return '--:--';
+    }
+    const hours = String(parsedDate.getHours()).padStart(2, '0');
+    const minutes = String(parsedDate.getMinutes()).padStart(2, '0');
+    return `${hours}:${minutes}`;
+  } catch (error) {
+    console.error('Error parsing date:', error);
+    return '--:--';
+  }
 };

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -8,11 +8,6 @@ export type Location = {
   };
 };
 
-type StayDuration = {
-  start: string; // 例: "10:00"
-  end: string; // 例: "11:30"
-};
-
 type Transport = {
   name: string; // 例: "電車" | "バス"
   time: string; // 例: "30分"
@@ -37,8 +32,9 @@ export type Spot = {
   name: string;
   latitude: number;
   longitude: number;
-  stay: StayDuration;
-  transport: Transport;
+  stayStart: string;
+  stayEnd: string;
+  transport?: Transport;
   memo?: string;
   image?: string; // 画像URL (省略可能)
   rating: number; // 例: 4.7


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    旅行計画関連のフィールド名を'stay'から'stayStart'と'stayEnd'に変更し、関連するコンポーネントでの修正を実施。これにより、データの整合性を向上させ、コードの可読性を改善。

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 滞在時間の表示形式を「HH:mm」に統一するユーティリティ関数を追加しました。

- **バグ修正**
  - スポットのカテゴリや交通手段が未定義の場合でもエラーが発生しないよう改善しました。

- **リファクタ**
  - スポットの滞在時間データ構造を、ネストされたオブジェクトから「stayStart」「stayEnd」の2つのフィールドに変更しました。
  - 交通手段情報を任意項目として扱うように変更しました。
  - ダミーデータの利用を廃止し、APIから取得した実データを表示するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->