### PR TITLE
🤖 [Auto] 旅行計画作成ページのカード幅を最大6xlに変更し、Ganttチャートコンポーネントに観光地削除ボタンを追加。旅行計画コンポーネントでの観光地名表示を改善し、型定義を更新。全体的なUIの整備と機能強化を実施。

### DIFF
--- a/frontend/src/app/plan/create/page.tsx
+++ b/frontend/src/app/plan/create/page.tsx
@@ -79,7 +79,7 @@ const TravelPlanCreate = () => {
     <div>
       <LoadScript googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY || ''}>
         <div className="container mx-auto p-4">
-          <Card className="w-full max-w-4xl mx-auto">
+          <Card className="w-full max-w-6xl mx-auto">
             <CardHeader>
               <CardTitle>旅行計画を作成</CardTitle>
             </CardHeader>

--- a/frontend/src/components/GanttChart.tsx
+++ b/frontend/src/components/GanttChart.tsx
@@ -2,12 +2,14 @@
 import { DndContext, DragEndEvent, DragMoveEvent, DragStartEvent } from '@dnd-kit/core';
 import { Fragment, useEffect, useState } from 'react';
 import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
+import { X } from 'lucide-react';
 
 import { calcDiffTime, updatedTime } from '@/lib/utils';
 import { Spot } from '@/types/plan';
 import { useStoreForPlanning } from '@/lib/plan';
 
 import { DraggableHandle, DroppableHandle } from './common/DndItem';
+import { Button } from './ui/button';
 
 const GanttChart = ({ date }: { date: string }) => {
   const fields = useStoreForPlanning();
@@ -170,22 +172,33 @@ const GanttChart = ({ date }: { date: string }) => {
     }
   };
 
+  const handleDeleteSpot = (id: string) => {
+    setSpots((prev) => prev.filter((spot) => spot.id !== id));
+  };
+
   if (timeSlots.length === 0 || !spots.length) {
     return <div>観光地を選択してください</div>;
   }
 
   return (
-    <div className="w-full max-w-6xl mx-auto p-4 flex">
+    <div className="w-full max-w-6xl mx-auto p-2 flex">
       {/* 観光地名 */}
-      <div className="w-64 flex-shrink-0">
+      <div className="w-96 flex-shrink-0">
         <div className="font-bold h-8 flex items-center justify-center bg-gray-200">観光地名</div>
-        {spots.length &&
+
+        {spots.length > 0 &&
           spots.map((spot, id) => (
-            <div key={id} className="h-16 flex items-center justify-center border-b border-gray-300 bg-gray-100">
-              {spot.name}
-              <div>
-                ({spot.stayStart} ~ {spot.stayEnd})
+            <div key={id} className="h-16 flex items-center justify-between border-b border-gray-300 bg-gray-100 px-3">
+              <div className="flex flex-col justify-center overflow-hidden">
+                <span className="text-sm font-medium truncate">{spot.name}</span>
+                <span className="text-xs text-gray-500">
+                  ({spot.stayStart} ~ {spot.stayEnd})
+                </span>
               </div>
+
+              <Button variant="ghost" size="icon" onClick={() => handleDeleteSpot(spot.id)}>
+                <X className="w-4 h-4 text-red-500" />
+              </Button>
             </div>
           ))}
       </div>

--- a/frontend/src/components/GanttChart.tsx
+++ b/frontend/src/components/GanttChart.tsx
@@ -174,6 +174,13 @@ const GanttChart = ({ date }: { date: string }) => {
 
   const handleDeleteSpot = (id: string) => {
     setSpots((prev) => prev.filter((spot) => spot.id !== id));
+    const filteredPlan = fields.plans.find((plan) => plan.date.toLocaleDateString('ja-JP') === date);
+    if (filteredPlan) {
+      const spot = filteredPlan.spots.find((spot) => spot.id === id);
+      if (spot) {
+        fields.setSpots(new Date(date), spot, true);
+      }
+    }
   };
 
   if (timeSlots.length === 0 || !spots.length) {

--- a/frontend/src/components/PlanningComp.tsx
+++ b/frontend/src/components/PlanningComp.tsx
@@ -92,13 +92,7 @@ const PlanningComp = ({ date }: { date: string }) => {
 
       {/* 作成ボタン */}
       <div className="space-y-2">
-        <Button
-          type="button"
-          variant={'outline'}
-          role="button"
-          // onClick={() => pickUpSightseeingAre()}
-          className="w-full"
-        >
+        <Button type="button" variant={'outline'} role="button" className="w-full">
           AIによるシミュレート
         </Button>
       </div>

--- a/frontend/src/components/TravelPlan.tsx
+++ b/frontend/src/components/TravelPlan.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MapPin, Clock, Train, Bus, FootprintsIcon, Info, Check } from 'lucide-react';
+import { MapPin, Clock, Train, Bus, FootprintsIcon, Info, Check, X } from 'lucide-react';
 import Image from 'next/image';
 
 import { TravelPlanType } from '@/types/plan';
@@ -9,6 +9,7 @@ import { useStoreForPlanning } from '@/lib/plan';
 import { Label } from './ui/label';
 import { Textarea } from './ui/textarea';
 import TravelMap from './TravelMap';
+import { Button } from './ui/button';
 
 const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
   const fields = useStoreForPlanning();
@@ -23,6 +24,11 @@ const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
     : null;
 
   const { departure, spots, destination, date } = travelPlan;
+
+  const handleDeleteSpot = (id: string) => {
+    const updatedSpots = spots.filter((spot) => spot.id == id)[0];
+    fields.setSpots(new Date(date), updatedSpots, true);
+  };
 
   const transportIcons: Record<string, JSX.Element> = {
     電車: <Train className="w-5 h-5 text-blue-500" />,
@@ -78,10 +84,13 @@ const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
 
       {/* 観光スポット */}
       {spots.map((spot, index) => (
-        <div key={index} className="mb-10 border-b border-gray-300 pb-6">
+        <div key={index} className="mb-10 border-b border-gray-300 pb-6 relative">
+          <Button variant="ghost" onClick={() => handleDeleteSpot(spot.id)} className="absolute top-0 right-0">
+            <X className="w-4 h-4 text-red-500" />
+          </Button>
           {/* 移動手段 */}
           <div className="flex items-center space-x-2  text-gray-600 mb-4">
-            {transportIcons[spot.transport.name]}
+            {transportIcons[spot?.transport?.name]}
             <span>
               {spot.transport.name} ({spot.transport.time})
             </span>
@@ -101,7 +110,7 @@ const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
             <p className="text-gray-500 flex items-center space-x-1 mt-1">
               <Clock className="w-4 h-4 text-gray-400" />
               <span>
-                {spot.stay.start} - {spot.stay.end}
+                {spot.stayStart} - {spot.stayEnd}
               </span>
             </p>
 

--- a/frontend/src/components/TravelPlan.tsx
+++ b/frontend/src/components/TravelPlan.tsx
@@ -84,7 +84,7 @@ const TravelPlan = ({ travelPlan }: { travelPlan: TravelPlanType }) => {
 
       {/* 観光スポット */}
       {spots.map((spot, index) => (
-        <div key={index} className="mb-10 border-b border-gray-300 pb-6 relative">
+        <div key={spot.id} className="mb-10 border-b border-gray-300 pb-6 relative">
           <Button variant="ghost" onClick={() => handleDeleteSpot(spot.id)} className="absolute top-0 right-0">
             <X className="w-4 h-4 text-red-500" />
           </Button>

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -39,7 +39,7 @@ export type Spot = {
   longitude: number;
   stayStart: string;
   stayEnd: string;
-  transport?: Transport;
+  transport: Transport;
   url?: string;
   memo?: string;
   image?: string; // 画像URL (省略可能)


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    旅行計画作成ページのカード幅を最大6xlに変更し、Ganttチャートコンポーネントに観光地削除ボタンを追加。旅行計画コンポーネントでの観光地名表示を改善し、型定義を更新。全体的なUIの整備と機能強化を実施。

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ガントチャートおよび旅行プラン画面で、観光スポットをリストから削除できるボタンを追加しました。

- **UI改善**
  - 旅行プラン作成フォームやスポットリストのカード幅を拡大し、大画面での表示を最適化しました。
  - スポットリストのレイアウトや表示方法を調整し、見やすさを向上しました。

- **バグ修正**
  - 滞在時間や交通手段の表示に関する不具合を修正しました。

- **その他**
  - スポットの「transport」項目が必須になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->