### PR TITLE
🤖 [Auto] #feature86  ガントチャート上の時間に応じて、順番を変更できるようにする #86

出発地と目的地コンポーネントに滞在開始・終了時間を追加し、Ganttチャートでの時間取得方法を最適化。プランニングボタンでスポットを開始時間でソートする機能を追加。プランの状態管理にスポット編集機能を追加し、スポット型のIDを必須に変更。

### DIFF
--- a/frontend/src/components/Departure.tsx
+++ b/frontend/src/components/Departure.tsx
@@ -54,6 +54,8 @@ const Departure = ({ date }: { date: string }) => {
                           latitude: departure.latitude,
                           longitude: departure.longitude,
                         },
+                        stayStart: '00:00',
+                        stayEnd: '00:00',
                         order: 0,
                         transports: {
                           travelTime: '不明',

--- a/frontend/src/components/Destination.tsx
+++ b/frontend/src/components/Destination.tsx
@@ -55,6 +55,8 @@ const Destination = ({ date }: { date: string }) => {
                           longitude: destination.longitude,
                         },
                         order: 0,
+                        stayStart: '00:00',
+                        stayEnd: '00:00',
                         transports: {
                           travelTime: '不明',
                           cost: 0,

--- a/frontend/src/components/GanttChart.tsx
+++ b/frontend/src/components/GanttChart.tsx
@@ -77,7 +77,7 @@ const GanttChart = ({ date }: { date: string }) => {
     if (event.over) {
       const [spotId, newTime] = event.over.id.toString().split('-').map(String);
       if (type === 'start') {
-        const endTime = spots.filter((activity) => activity.id === draggingId)[0].stayEnd || '24:00';
+        const endTime = spots.find((activity) => activity.id == draggingId)?.stayEnd || '24:00';
         // 始点が終点を超える場合はこれ以上ドラッグしない
         if (newTime >= endTime) {
           return;
@@ -86,7 +86,7 @@ const GanttChart = ({ date }: { date: string }) => {
           prev.map((activity) => (activity.id === draggingId ? { ...activity, start: newTime } : activity)),
         );
       } else if (type === 'end') {
-        const startTime = spots.filter((activity) => activity.id === draggingId)[0].stayStart || '24:00';
+        const startTime = spots.find((activity) => activity.id === draggingId)?.stayStart || '24:00';
         // 終点が始点を下回る場合はこれ以上ドラッグしない
         if (newTime <= startTime) {
           return;
@@ -96,8 +96,8 @@ const GanttChart = ({ date }: { date: string }) => {
         );
       } else {
         //現在の時間を取得
-        const startTime = spots.filter((activity) => activity.id === draggingId)[0].stayStart || '24:00';
-        const endTime = spots.filter((activity) => activity.id === draggingId)[0].stayEnd || '24:00';
+        const startTime = spots.find((activity) => activity.id === draggingId)?.stayStart || '24:00';
+        const endTime = spots.find((activity) => activity.id === draggingId)?.stayEnd || '24:00';
         //選択している時間とドロップ先の差分を取得
         const diffTime = calcDiffTime(newTime, type);
         //差分をもとに始点と終点を更新
@@ -112,10 +112,10 @@ const GanttChart = ({ date }: { date: string }) => {
     const [draggedId, type] = event.active.id.toString().split('-').map(String);
     if (event.over) {
       const [spotId, newTime] = event.over.id.toString().split('-').map(String);
-      const prevData = spots.filter((activity) => activity.id === spotId)[0];
+      const prevData = spots.find((activity) => activity.id === spotId);
       // 始点が終点を超える場合は反映させない
       if (type === 'start') {
-        if (newTime > (prevData.stayEnd || '24:00')) {
+        if (newTime > (prevData?.stayEnd || '24:00')) {
           return;
         }
         setDraggedItems((prev) =>
@@ -129,7 +129,7 @@ const GanttChart = ({ date }: { date: string }) => {
         }
       } else if (type === 'end') {
         // 終点が始点を下回る場合は反映しない
-        if (newTime < (prevData.stayStart || '24:00')) {
+        if (newTime < (prevData?.stayStart || '24:00')) {
           return;
         }
         setDraggedItems((prev) =>
@@ -144,8 +144,8 @@ const GanttChart = ({ date }: { date: string }) => {
         }
       } else {
         //現在の時間を取得
-        const startTime = spots.filter((activity) => activity.id === spotId)[0].stayStart || '24:00';
-        const endTime = spots.filter((activity) => activity.id === spotId)[0].stayEnd || '24:00';
+        const startTime = spots.find((activity) => activity.id === spotId)?.stayStart || '24:00';
+        const endTime = spots.find((activity) => activity.id === spotId)?.stayEnd || '24:00';
         //選択している時間とドロップ先の差分を取得
         const diffTime = calcDiffTime(newTime, type);
         //差分をもとに始点と終点を更新

--- a/frontend/src/components/PlanningButton.tsx
+++ b/frontend/src/components/PlanningButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useStoreForPlanning } from '@/lib/plan';
+import { sortSpotByStartTime } from '@/lib/algorithm';
 
 import { Button } from './ui/button';
 
@@ -68,6 +69,15 @@ const PlanningButton = ({ date }: { date: string }) => {
 
     fields.setSimulationStatus({ date: new Date(date), status: 1 });
     alert('プランニング中です');
+
+    // 開始時間を元にスポットをソートする
+    const sortedSpots = sortSpotByStartTime(targetPlans.spots);
+
+    // ソート後の順番を反映処理
+    sortedSpots.forEach((spot) => {
+      fields.editSpots(new Date(date), spot.spotId, { order: spot.order });
+    });
+
     //TODO: 非同期でプラン作成をシミュレーションする機能の追加
     setTimeout(() => {
       fields.setSimulationStatus({ date: new Date(date), status: 2 });

--- a/frontend/src/components/TravelMap.tsx
+++ b/frontend/src/components/TravelMap.tsx
@@ -40,21 +40,11 @@ const TravelMap = ({ travelPlan }: TravelMapProps) => {
   const [selectedMarker, setSelectedMarker] = useState<{ lat: number; lng: number; name: string } | null>(null);
   const [map, setMap] = useState<google.maps.Map | null>(null);
 
-  const departureData = fields.plans
-    .filter((val) => val.date.toLocaleDateString('ja-JP') == new Date(travelPlan.date).toLocaleDateString('ja-JP'))[0]
-    ?.spots.filter((spot) => spot.transports?.fromType === TransportNodeType.DEPARTURE)[0];
+  const departureData = fields.getSpotInfo(travelPlan.date, TransportNodeType.DEPARTURE)[0];
 
-  const destinationData = fields.plans
-    .filter((val) => val.date.toLocaleDateString('ja-JP') == new Date(travelPlan.date).toLocaleDateString('ja-JP'))[0]
-    ?.spots.filter((spot) => spot.transports?.toType === TransportNodeType.DESTINATION)[0];
+  const destinationData = fields.getSpotInfo(travelPlan.date, TransportNodeType.DESTINATION)[0];
 
-  const spots = fields.plans
-    .filter((val) => val.date.toLocaleDateString('ja-JP') == new Date(travelPlan.date).toLocaleDateString('ja-JP'))[0]
-    ?.spots.filter(
-      (spot) =>
-        spot.transports?.toType !== TransportNodeType.DESTINATION &&
-        spot.transports?.fromType !== TransportNodeType.DEPARTURE,
-    );
+  const spots = fields.getSpotInfo(travelPlan.date, TransportNodeType.SPOT);
 
   // ルートを計算
   useEffect(() => {

--- a/frontend/src/lib/algorithm.ts
+++ b/frontend/src/lib/algorithm.ts
@@ -1,0 +1,32 @@
+import { Spot } from '@/types/plan';
+
+interface SortedSpot {
+  order: number;
+  spotId: string;
+}
+
+export const sortSpotByStartTime = (spots: Spot[]): SortedSpot[] => {
+  if (!spots || spots.length === 0) {
+    return [];
+  }
+
+  // 出発地と目的地は除外する
+  spots = spots.filter((spot) => spot.stayStart !== undefined && spot.stayEnd !== undefined);
+  //
+  spots.sort((a, b) => {
+    const startA = a.stayStart ?? '00:00';
+    const startB = b.stayStart ?? '00:00';
+
+    const startATotalTime = parseInt(startA.split(':')[0]) * 60 + parseInt(startA.split(':')[1]);
+    const startBTotalTime = parseInt(startB.split(':')[0]) * 60 + parseInt(startB.split(':')[1]);
+    return startATotalTime - startBTotalTime;
+  });
+
+  // ソート後に連番を振り直す
+  const sortedSpots: SortedSpot[] = spots.map((spot, index) => ({
+    order: index + 1,
+    spotId: spot.id,
+  }));
+
+  return sortedSpots;
+};

--- a/frontend/src/lib/algorithm.ts
+++ b/frontend/src/lib/algorithm.ts
@@ -1,4 +1,4 @@
-import { Spot } from '@/types/plan';
+import { Spot, TransportNodeType } from '@/types/plan';
 
 interface SortedSpot {
   order: number;
@@ -11,7 +11,10 @@ export const sortSpotByStartTime = (spots: Spot[]): SortedSpot[] => {
   }
 
   // 出発地と目的地は除外する
-  spots = spots.filter((spot) => spot.stayStart !== undefined && spot.stayEnd !== undefined);
+  spots = spots.filter(
+    (spot) =>
+      spot.transports?.fromType === TransportNodeType.SPOT && spot.transports?.toType === TransportNodeType.SPOT,
+  );
   //
   spots.sort((a, b) => {
     const startA = a.stayStart ?? '00:00';

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -39,10 +39,10 @@ export type TripInfo = {
 };
 
 export type Spot = {
-  id?: string;
+  id: string;
   location: Location;
-  stayStart?: string;
-  stayEnd?: string;
+  stayStart: string;
+  stayEnd: string;
   transports: Transport;
   url?: string;
   memo?: string;


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    #feature86  ガントチャート上の時間に応じて、順番を変更できるようにする #86

出発地と目的地コンポーネントに滞在開始・終了時間を追加し、Ganttチャートでの時間取得方法を最適化。プランニングボタンでスポットを開始時間でソートする機能を追加。プランの状態管理にスポット編集機能を追加し、スポット型のIDを必須に変更。

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 出発地・目的地スポットに「滞在開始時刻（stayStart）」と「滞在終了時刻（stayEnd）」が追加されました。
  * プランのスポットを開始時刻順に並び替える機能を追加しました。

* **改善**
  * ガントチャートの内部処理が安全かつ効率的になりました。
  * マップ表示のスポット取得処理が整理され、可読性が向上しました。

* **型定義の変更**
  * スポット情報（Spot型）の「id」「stayStart」「stayEnd」が必須項目となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->