### PR TITLE
🤖 [Auto] #feature87 観光スポットの終了時間の自動設定

観光スポット選択時に前の終了時間を元に開始時間をずらして設定する

### DIFF
--- a/frontend/src/components/SpotSelection.tsx
+++ b/frontend/src/components/SpotSelection.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { CheckIcon, Search } from 'lucide-react';
 
 import { searchSpots, useStoreForPlanning } from '@/lib/plan';
+import { setStartTimeAutomatically } from '@/lib/algorithm';
 import { PlaceTypeGroupKey, SortOption } from '@/types/plan';
 import { useMapStore } from '@/stores/mapStore';
 import { prefectureCenters, prefectures } from '@/data/dummyData';
@@ -170,6 +171,11 @@ const SpotSelection = ({ date }: { date: string }) => {
                       const isSelected = selectedSpots.some((s) => s.location.name === spot.location.name);
 
                       if (!isSelected) {
+                        // スポットの開始時間を前スポットの終了時間を基準に設定
+                        spot = setStartTimeAutomatically(
+                          spot,
+                          fields.plans.filter((val) => val.date.toLocaleDateString('ja-JP') === date)[0]?.spots,
+                        );
                         fields.setSpots(new Date(date), spot, false);
                       } else {
                         fields.setSpots(new Date(date), spot, true);

--- a/frontend/src/lib/algorithm.ts
+++ b/frontend/src/lib/algorithm.ts
@@ -47,6 +47,12 @@ export const sortSpotByStartTime = (spots: Spot[]): SortedSpot[] => {
  */
 export const setStartTimeAutomatically = (newSpot: Spot, spots: Spot[]): Spot => {
   const clonedNewSpot = { ...newSpot };
+  // 出発地と目的地は除外する
+  spots = spots.filter(
+    (spot) =>
+      spot.transports?.fromType === TransportNodeType.SPOT && spot.transports?.toType === TransportNodeType.SPOT,
+  );
+
   if (spots.length == 0) {
     // 最初のスポットの場合は09:00で設定
     // TODO: どこかで管理する
@@ -56,11 +62,6 @@ export const setStartTimeAutomatically = (newSpot: Spot, spots: Spot[]): Spot =>
   }
 
   // 末尾に設定されている観光スポットの終了時間を元に開始時間を設定
-  // 出発地と目的地は除外する
-  spots = spots.filter(
-    (spot) =>
-      spot.transports?.fromType === TransportNodeType.SPOT && spot.transports?.toType === TransportNodeType.SPOT,
-  );
 
   // 前スポットの終了時間+1時間の幅で更新をかける
   const lastSpotEndTime = spots[spots.length - 1].stayEnd;

--- a/frontend/src/lib/algorithm.ts
+++ b/frontend/src/lib/algorithm.ts
@@ -5,6 +5,11 @@ interface SortedSpot {
   spotId: string;
 }
 
+/**
+ * 開始時間の昇順でソートを行い、orderを更新するための関数
+ * @param spots 観光スポットの配列
+ * @returns 観光地の順序とspotIdの配列(これを元にロジック側で更新をかける)
+ */
 export const sortSpotByStartTime = (spots: Spot[]): SortedSpot[] => {
   if (!spots || spots.length === 0) {
     return [];
@@ -32,4 +37,47 @@ export const sortSpotByStartTime = (spots: Spot[]): SortedSpot[] => {
   }));
 
   return sortedSpots;
+};
+
+/**
+ * 観光スポットが選択された際に、開始時間を自動的に設定する関数
+ * @param newSpot 新たに選択された観光スポット
+ * @param spots 既に選択済みの観光スポット
+ * @return 開始時間と終了時間が更新された観光スポット
+ */
+export const setStartTimeAutomatically = (newSpot: Spot, spots: Spot[]): Spot => {
+  const clonedNewSpot = { ...newSpot };
+  if (spots.length == 0) {
+    // 最初のスポットの場合は09:00で設定
+    // TODO: どこかで管理する
+    clonedNewSpot.stayStart = '09:00';
+    clonedNewSpot.stayEnd = '10:00';
+    return clonedNewSpot;
+  }
+
+  // 末尾に設定されている観光スポットの終了時間を元に開始時間を設定
+  // 出発地と目的地は除外する
+  spots = spots.filter(
+    (spot) =>
+      spot.transports?.fromType === TransportNodeType.SPOT && spot.transports?.toType === TransportNodeType.SPOT,
+  );
+
+  // 前スポットの終了時間+1時間の幅で更新をかける
+  const lastSpotEndTime = spots[spots.length - 1].stayEnd;
+  const [lastHour, lastMinute] = lastSpotEndTime.split(':').map(Number);
+  const newStartHour = lastHour + Math.floor(lastMinute / 60);
+  const newEndHour = newStartHour + 1;
+
+  // 24時を超えて設定される場合は補正処理をかける
+  // TODO: 需要があれば翌日の時間帯に設定等も考える
+  if (newStartHour >= 24) {
+    clonedNewSpot.stayStart = `23:${String(lastMinute % 60).padStart(2, '0')}`;
+    clonedNewSpot.stayEnd = `24:${String(lastMinute % 60).padStart(2, '0')}`;
+    return clonedNewSpot;
+  }
+
+  clonedNewSpot.stayStart = `${String(newStartHour).padStart(2, '0')}:${String(lastMinute % 60).padStart(2, '0')}`;
+  clonedNewSpot.stayEnd = `${String(newEndHour).padStart(2, '0')}:${String(lastMinute % 60).padStart(2, '0')}`;
+
+  return clonedNewSpot;
 };


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    #feature87 観光スポットの終了時間の自動設定

観光スポット選択時に前の終了時間を元に開始時間をずらして設定する

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 観光スポット選択時、前のスポットの終了時刻に基づいて自動的に開始時刻が設定されるようになりました。  
* **改善**
  * スポット追加時の時刻設定がより直感的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->