### PR TITLE
🤖 [Auto] #feature93
作成画面で設定した時間が表示されない

* 画面から取得したstayStartとstayEndを元にDBへ登録
* フォーマットをUTCで統一

### DIFF
--- a/backend/src/controllers/trip.ts
+++ b/backend/src/controllers/trip.ts
@@ -205,8 +205,12 @@ export const getTripHandler = {
                   planSpots: {
                     create: plan.spots.map((spot) => ({
                       spotId: spot.id,
-                      stayStart: new Date(plan.date),
-                      stayEnd: new Date(plan.date),
+                      stayStart: new Date(
+                        new Date(plan.date).toLocaleDateString('ja-JP').split(' ')[0] + ' ' + spot.stayStart,
+                      ),
+                      stayEnd: new Date(
+                        new Date(plan.date).toLocaleDateString('ja-JP').split(' ')[0] + ' ' + spot.stayEnd,
+                      ),
                       memo: spot.memo ?? null,
                       order: spot.order, // スポットの順序を設定
                     })),

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -111,8 +111,9 @@ export const formatToHHmm = (date: string): string => {
       console.error('Invalid date:', date);
       return '--:--';
     }
-    const hours = String(parsedDate.getHours()).padStart(2, '0');
-    const minutes = String(parsedDate.getMinutes()).padStart(2, '0');
+    // 現状世界標準時で定義しているためUTCを使用(もしかしたら今後変更するかもしれない)
+    const hours = String(parsedDate.getUTCHours()).padStart(2, '0');
+    const minutes = String(parsedDate.getUTCMinutes()).padStart(2, '0');
     return `${hours}:${minutes}`;
   } catch (error) {
     console.error('Error parsing date:', error);


### PR DESCRIPTION
## 自動生成されたPR
    このPRはGitHub Actionsによって自動的に作成されました。

    ### 変更内容
    #feature93
作成画面で設定した時間が表示されない

* 画面から取得したstayStartとstayEndを元にDBへ登録
* フォーマットをUTCで統一

    ### レビュー依頼
    @coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プランスポットの滞在開始・終了日時に、日付だけでなく時刻情報も正しく反映されるようになりました。
  * 時刻フォーマット処理がUTC基準で行われるようになり、時間表示のズレが修正されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->